### PR TITLE
Use logical classes for button

### DIFF
--- a/RetailredStorefront/Resources/config.xml
+++ b/RetailredStorefront/Resources/config.xml
@@ -299,7 +299,7 @@
             <name>reserveButtonClasses</name>
             <label lang="de">Reservieren Button Klassen</label>
             <label lang="en">Reserve button classes</label>
-            <value>button btn btn-primary</value>
+            <value>block btn is--secondary is--center is--large</value>
             <description lang="de">
                 Fügt Klassen zum Reservieren-Button hinzu. Das Setting kann dazu benutzt werden,  um den Button ihrem CI anzupassen.
             </description>


### PR DESCRIPTION
Based on Shopware core

https://github.com/shopware/shopware/blob/5.7/themes/Frontend/Bare/frontend/detail/buy.tpl#L81

- Instead of primary use secondary for different UI (Fits into Shopware CI guide)
- `is--icon-right` is missing because you have no `<i>`-Tag with the icon
- `btn-primary` is no Shopware class
- block should apply the same behavior as the buy button
- `is--center` is centering the text
- `is--large` fits the style of the section (same as buy button)